### PR TITLE
Split homepage into two tabs

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -62,90 +62,97 @@ gdp_df = get_gdp_data()
 # -----------------------------------------------------------------------------
 # Draw the actual page
 
-# Set the title that appears at the top of the page.
-'''
-# :earth_americas: GDP dashboard
+dashboard_tab, info_tab = st.tabs(["대시보드", "정보"])
 
-Browse GDP data from the [World Bank Open Data](https://data.worldbank.org/) website. As you'll
-notice, the data only goes to 2022 right now, and datapoints for certain years are often missing.
-But it's otherwise a great (and did I mention _free_?) source of data.
-'''
+with dashboard_tab:
+    # Set the title that appears at the top of the page.
+    '''
+    # :earth_americas: GDP dashboard
 
-# Add some spacing
-''
-''
+    Browse GDP data from the [World Bank Open Data](https://data.worldbank.org/) website. As you'll
+    notice, the data only goes to 2022 right now, and datapoints for certain years are often missing.
+    But it's otherwise a great (and did I mention _free_?) source of data.
+    '''
 
-min_value = gdp_df['Year'].min()
-max_value = gdp_df['Year'].max()
+    # Add some spacing
+    ''
+    ''
 
-from_year, to_year = st.slider(
-    'Which years are you interested in?',
-    min_value=min_value,
-    max_value=max_value,
-    value=[min_value, max_value])
+    min_value = gdp_df['Year'].min()
+    max_value = gdp_df['Year'].max()
 
-countries = gdp_df['Country Code'].unique()
+    from_year, to_year = st.slider(
+        'Which years are you interested in?',
+        min_value=min_value,
+        max_value=max_value,
+        value=[min_value, max_value])
 
-if not len(countries):
-    st.warning("Select at least one country")
+    countries = gdp_df['Country Code'].unique()
 
-selected_countries = st.multiselect(
-    'Which countries would you like to view?',
-    countries,
-    ['DEU', 'FRA', 'GBR', 'BRA', 'MEX', 'JPN'])
+    if not len(countries):
+        st.warning("Select at least one country")
 
-''
-''
-''
+    selected_countries = st.multiselect(
+        'Which countries would you like to view?',
+        countries,
+        ['DEU', 'FRA', 'GBR', 'BRA', 'MEX', 'JPN'])
 
-# Filter the data
-filtered_gdp_df = gdp_df[
-    (gdp_df['Country Code'].isin(selected_countries))
-    & (gdp_df['Year'] <= to_year)
-    & (from_year <= gdp_df['Year'])
-]
+    ''
+    ''
+    ''
 
-st.header('GDP over time', divider='gray')
+    # Filter the data
+    filtered_gdp_df = gdp_df[
+        (gdp_df['Country Code'].isin(selected_countries))
+        & (gdp_df['Year'] <= to_year)
+        & (from_year <= gdp_df['Year'])
+    ]
 
-''
+    st.header('GDP over time', divider='gray')
 
-st.line_chart(
-    filtered_gdp_df,
-    x='Year',
-    y='GDP',
-    color='Country Code',
-)
+    ''
 
-''
-''
+    st.line_chart(
+        filtered_gdp_df,
+        x='Year',
+        y='GDP',
+        color='Country Code',
+    )
 
+    ''
+    ''
+    ''
 
-first_year = gdp_df[gdp_df['Year'] == from_year]
-last_year = gdp_df[gdp_df['Year'] == to_year]
+    first_year = gdp_df[gdp_df['Year'] == from_year]
+    last_year = gdp_df[gdp_df['Year'] == to_year]
 
-st.header(f'GDP in {to_year}', divider='gray')
+    st.header(f'GDP in {to_year}', divider='gray')
 
-''
+    ''
 
-cols = st.columns(4)
+    cols = st.columns(4)
 
-for i, country in enumerate(selected_countries):
-    col = cols[i % len(cols)]
+    for i, country in enumerate(selected_countries):
+        col = cols[i % len(cols)]
 
-    with col:
-        first_gdp = first_year[first_year['Country Code'] == country]['GDP'].iat[0] / 1000000000
-        last_gdp = last_year[last_year['Country Code'] == country]['GDP'].iat[0] / 1000000000
+        with col:
+            first_gdp = first_year[first_year['Country Code'] == country]['GDP'].iat[0] / 1000000000
+            last_gdp = last_year[last_year['Country Code'] == country]['GDP'].iat[0] / 1000000000
 
-        if math.isnan(first_gdp):
-            growth = 'n/a'
-            delta_color = 'off'
-        else:
-            growth = f'{last_gdp / first_gdp:,.2f}x'
-            delta_color = 'normal'
+            if math.isnan(first_gdp):
+                growth = 'n/a'
+                delta_color = 'off'
+            else:
+                growth = f'{last_gdp / first_gdp:,.2f}x'
+                delta_color = 'normal'
 
-        st.metric(
-            label=f'{country} GDP',
-            value=f'{last_gdp:,.0f}B',
-            delta=growth,
-            delta_color=delta_color
-        )
+            st.metric(
+                label=f'{country} GDP',
+                value=f'{last_gdp:,.0f}B',
+                delta=growth,
+                delta_color=delta_color
+            )
+
+with info_tab:
+    st.header('정보', divider='gray')
+    st.write('이 탭에는 간단한 텍스트가 표시됩니다.')


### PR DESCRIPTION
Add two tabs to the homepage, moving existing content to one tab and displaying new text in the other.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec4ca0f4-4fbc-4515-ac02-262a623ecbd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec4ca0f4-4fbc-4515-ac02-262a623ecbd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

